### PR TITLE
Remove an unnecessary package dependency.

### DIFF
--- a/ApplicationCore.vb/ApplicationCore.vb.vbproj
+++ b/ApplicationCore.vb/ApplicationCore.vb.vbproj
@@ -7,7 +7,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Ardalis.GuardClauses" Version="1.4.2" />
-		<PackageReference Include="System.Security.Claims" Version="4.3.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
It is not required; even on .NET Core 3.1.